### PR TITLE
fix cutting recipes for avocado log/wood

### DIFF
--- a/src/main/resources/data/culturaldelights/recipes/cutting/avocado_log.json
+++ b/src/main/resources/data/culturaldelights/recipes/cutting/avocado_log.json
@@ -6,8 +6,8 @@
     }
   ],
   "tool": {
-    "type": "farmersdelight:tool",
-    "tool": "axe"
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
   },
   "result": [
     {

--- a/src/main/resources/data/culturaldelights/recipes/cutting/avocado_wood.json
+++ b/src/main/resources/data/culturaldelights/recipes/cutting/avocado_wood.json
@@ -6,8 +6,8 @@
     }
   ],
   "tool": {
-    "type": "farmersdelight:tool",
-    "tool": "axe"
+    "type": "farmersdelight:tool_action",
+    "action": "axe_strip"
   },
   "result": [
     {


### PR DESCRIPTION
I ran into some errors in KubeJS because these recipes didn't work with FarmersDelight-1.19.2-1.2.3.jar